### PR TITLE
Fix: encoding ruby comment

### DIFF
--- a/app/controllers/admin/home_controller.rb
+++ b/app/controllers/admin/home_controller.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 # Copyright (C) 2012  TEA, the ebook alternative <http://www.tea-ebook.com/>
 # 
 # This file is part of TeaBook Open Reader
@@ -19,9 +21,6 @@
 # You should have received a copy of this exception. If not, see 
 # <https://github.com/TEA-ebook/teabook-open-reader/blob/master/GPL-3-EXCEPTION>.
 
-
-
-# encoding: utf-8
 
 class Admin::HomeController < AdminController
 

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 # Copyright (C) 2012  TEA, the ebook alternative <http://www.tea-ebook.com/>
 # 
 # This file is part of TeaBook Open Reader
@@ -20,8 +22,6 @@
 # <https://github.com/TEA-ebook/teabook-open-reader/blob/master/GPL-3-EXCEPTION>.
 
 
-
-# encoding: utf-8
 
 class AdminController < ActionController::Base
   protect_from_forgery

--- a/app/controllers/annotations_controller.rb
+++ b/app/controllers/annotations_controller.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 # Copyright (C) 2012  TEA, the ebook alternative <http://www.tea-ebook.com/>
 # 
 # This file is part of TeaBook Open Reader
@@ -19,9 +21,6 @@
 # You should have received a copy of this exception. If not, see 
 # <https://github.com/TEA-ebook/teabook-open-reader/blob/master/GPL-3-EXCEPTION>.
 
-
-
-# encoding: utf-8
 
 class AnnotationsController < ApplicationController
   before_filter :authenticate_user!

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 # Copyright (C) 2012  TEA, the ebook alternative <http://www.tea-ebook.com/>
 # 
 # This file is part of TeaBook Open Reader
@@ -19,9 +21,6 @@
 # You should have received a copy of this exception. If not, see 
 # <https://github.com/TEA-ebook/teabook-open-reader/blob/master/GPL-3-EXCEPTION>.
 
-
-
-# encoding: utf-8
 
 class ApplicationController < ActionController::Base
   protect_from_forgery

--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 # Copyright (C) 2012  TEA, the ebook alternative <http://www.tea-ebook.com/>
 # 
 # This file is part of TeaBook Open Reader
@@ -20,8 +22,6 @@
 # <https://github.com/TEA-ebook/teabook-open-reader/blob/master/GPL-3-EXCEPTION>.
 
 
-
-# encoding: utf-8
 class BookmarksController < ApplicationController
   helper_method :book, :bookmarks
 

--- a/app/controllers/ebook/epub/chapters_controller.rb
+++ b/app/controllers/ebook/epub/chapters_controller.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 # Copyright (C) 2012  TEA, the ebook alternative <http://www.tea-ebook.com/>
 # 
 # This file is part of TeaBook Open Reader
@@ -19,9 +21,6 @@
 # You should have received a copy of this exception. If not, see 
 # <https://github.com/TEA-ebook/teabook-open-reader/blob/master/GPL-3-EXCEPTION>.
 
-
-
-# encoding: utf-8
 
 # TODO spec
 class Ebook::Epub::ChaptersController < ApplicationController

--- a/app/controllers/ebook/epub/components_controller.rb
+++ b/app/controllers/ebook/epub/components_controller.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 # Copyright (C) 2012  TEA, the ebook alternative <http://www.tea-ebook.com/>
 # 
 # This file is part of TeaBook Open Reader
@@ -20,8 +22,6 @@
 # <https://github.com/TEA-ebook/teabook-open-reader/blob/master/GPL-3-EXCEPTION>.
 
 
-
-# encoding: utf-8
 
 # TODO spec
 class Ebook::Epub::ComponentsController < ApplicationController

--- a/app/controllers/ebook/epubs_controller.rb
+++ b/app/controllers/ebook/epubs_controller.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 # Copyright (C) 2012  TEA, the ebook alternative <http://www.tea-ebook.com/>
 # 
 # This file is part of TeaBook Open Reader
@@ -20,8 +22,6 @@
 # <https://github.com/TEA-ebook/teabook-open-reader/blob/master/GPL-3-EXCEPTION>.
 
 
-
-# encoding: utf-8
 
 # TODO spec
 class Ebook::EpubsController < ApplicationController

--- a/app/controllers/manifests_controller.rb
+++ b/app/controllers/manifests_controller.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 # Copyright (C) 2012  TEA, the ebook alternative <http://www.tea-ebook.com/>
 # 
 # This file is part of TeaBook Open Reader
@@ -20,8 +22,6 @@
 # <https://github.com/TEA-ebook/teabook-open-reader/blob/master/GPL-3-EXCEPTION>.
 
 
-
-# encoding: utf-8
 class ManifestsController < ApplicationController
 
   def loader

--- a/app/controllers/reading_position_controller.rb
+++ b/app/controllers/reading_position_controller.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 # Copyright (C) 2012  TEA, the ebook alternative <http://www.tea-ebook.com/>
 # 
 # This file is part of TeaBook Open Reader
@@ -19,9 +21,6 @@
 # You should have received a copy of this exception. If not, see 
 # <https://github.com/TEA-ebook/teabook-open-reader/blob/master/GPL-3-EXCEPTION>.
 
-
-
-# encoding: utf-8
 
 class ReadingPositionController < ApplicationController
   before_filter :authenticate_user!

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 # Copyright (C) 2012  TEA, the ebook alternative <http://www.tea-ebook.com/>
 # 
 # This file is part of TeaBook Open Reader
@@ -20,8 +22,6 @@
 # <https://github.com/TEA-ebook/teabook-open-reader/blob/master/GPL-3-EXCEPTION>.
 
 
-
-# encoding: utf-8
 module ApplicationHelper
 
   # Return the stylesheet link tag for the current Bookseller

--- a/app/helpers/manifests_helper.rb
+++ b/app/helpers/manifests_helper.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 # Copyright (C) 2012  TEA, the ebook alternative <http://www.tea-ebook.com/>
 # 
 # This file is part of TeaBook Open Reader
@@ -20,8 +22,6 @@
 # <https://github.com/TEA-ebook/teabook-open-reader/blob/master/GPL-3-EXCEPTION>.
 
 
-
-# encoding: utf-8
 module ManifestsHelper
 
   def reader_file_list

--- a/app/models/annotation.rb
+++ b/app/models/annotation.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 # Copyright (C) 2012  TEA, the ebook alternative <http://www.tea-ebook.com/>
 # 
 # This file is part of TeaBook Open Reader
@@ -19,9 +21,6 @@
 # You should have received a copy of this exception. If not, see 
 # <https://github.com/TEA-ebook/teabook-open-reader/blob/master/GPL-3-EXCEPTION>.
 
-
-
-# encoding: utf-8
 
 class Annotation < BookLocation
   field :end_xpath,       type: String

--- a/app/models/book_location.rb
+++ b/app/models/book_location.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 # Copyright (C) 2012  TEA, the ebook alternative <http://www.tea-ebook.com/>
 # 
 # This file is part of TeaBook Open Reader
@@ -19,9 +21,6 @@
 # You should have received a copy of this exception. If not, see 
 # <https://github.com/TEA-ebook/teabook-open-reader/blob/master/GPL-3-EXCEPTION>.
 
-
-
-# encoding: utf-8
 
 class BookLocation
   include Mongoid::Document

--- a/app/models/bookmark.rb
+++ b/app/models/bookmark.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 # Copyright (C) 2012  TEA, the ebook alternative <http://www.tea-ebook.com/>
 # 
 # This file is part of TeaBook Open Reader
@@ -19,9 +21,6 @@
 # You should have received a copy of this exception. If not, see 
 # <https://github.com/TEA-ebook/teabook-open-reader/blob/master/GPL-3-EXCEPTION>.
 
-
-
-# encoding: utf-8
 
 class Bookmark < BookLocation
   attr_accessible :book, :component_name, :start_xpath, :device, :epub_cfi

--- a/app/models/ebook/base.rb
+++ b/app/models/ebook/base.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 # Copyright (C) 2012  TEA, the ebook alternative <http://www.tea-ebook.com/>
 # 
 # This file is part of TeaBook Open Reader
@@ -19,9 +21,6 @@
 # You should have received a copy of this exception. If not, see 
 # <https://github.com/TEA-ebook/teabook-open-reader/blob/master/GPL-3-EXCEPTION>.
 
-
-
-# encoding: utf-8
 
 class Ebook::Base
   include Mongoid::Document

--- a/app/models/ebook/epub.rb
+++ b/app/models/ebook/epub.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 # Copyright (C) 2012  TEA, the ebook alternative <http://www.tea-ebook.com/>
 # 
 # This file is part of TeaBook Open Reader
@@ -19,9 +21,6 @@
 # You should have received a copy of this exception. If not, see 
 # <https://github.com/TEA-ebook/teabook-open-reader/blob/master/GPL-3-EXCEPTION>.
 
-
-
-# encoding: utf-8
 
 require "shellwords"
 

--- a/app/models/ebook/epub/chapter.rb
+++ b/app/models/ebook/epub/chapter.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 # Copyright (C) 2012  TEA, the ebook alternative <http://www.tea-ebook.com/>
 # 
 # This file is part of TeaBook Open Reader
@@ -19,9 +21,6 @@
 # You should have received a copy of this exception. If not, see 
 # <https://github.com/TEA-ebook/teabook-open-reader/blob/master/GPL-3-EXCEPTION>.
 
-
-
-# encoding: utf-8
 
 class Ebook::Epub::Chapter
   include Mongoid::Document

--- a/app/models/ebook/epub/component.rb
+++ b/app/models/ebook/epub/component.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 # Copyright (C) 2012  TEA, the ebook alternative <http://www.tea-ebook.com/>
 # 
 # This file is part of TeaBook Open Reader
@@ -19,9 +21,6 @@
 # You should have received a copy of this exception. If not, see 
 # <https://github.com/TEA-ebook/teabook-open-reader/blob/master/GPL-3-EXCEPTION>.
 
-
-
-# encoding: utf-8
 
 class Ebook::Epub::Component
   include Mongoid::Document

--- a/app/models/epub_cfi.rb
+++ b/app/models/epub_cfi.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 # Copyright (C) 2012  TEA, the ebook alternative <http://www.tea-ebook.com/>
 # 
 # This file is part of TeaBook Open Reader
@@ -19,9 +21,6 @@
 # You should have received a copy of this exception. If not, see 
 # <https://github.com/TEA-ebook/teabook-open-reader/blob/master/GPL-3-EXCEPTION>.
 
-
-
-# encoding: utf-8
 
 class EpubCfi
 

--- a/app/models/reading_position.rb
+++ b/app/models/reading_position.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 # Copyright (C) 2012  TEA, the ebook alternative <http://www.tea-ebook.com/>
 # 
 # This file is part of TeaBook Open Reader
@@ -19,9 +21,6 @@
 # You should have received a copy of this exception. If not, see 
 # <https://github.com/TEA-ebook/teabook-open-reader/blob/master/GPL-3-EXCEPTION>.
 
-
-
-# encoding: utf-8
 
 class ReadingPosition < Bookmark
   field :locus,       type: Hash

--- a/app/models/synchronizers/base.rb
+++ b/app/models/synchronizers/base.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 # Copyright (C) 2012  TEA, the ebook alternative <http://www.tea-ebook.com/>
 # 
 # This file is part of TeaBook Open Reader
@@ -19,9 +21,6 @@
 # You should have received a copy of this exception. If not, see 
 # <https://github.com/TEA-ebook/teabook-open-reader/blob/master/GPL-3-EXCEPTION>.
 
-
-
-# encoding: utf-8
 
 module Synchronizers
   class Base

--- a/app/models/synchronizers/reading_position.rb
+++ b/app/models/synchronizers/reading_position.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 # Copyright (C) 2012  TEA, the ebook alternative <http://www.tea-ebook.com/>
 # 
 # This file is part of TeaBook Open Reader
@@ -19,9 +21,6 @@
 # You should have received a copy of this exception. If not, see 
 # <https://github.com/TEA-ebook/teabook-open-reader/blob/master/GPL-3-EXCEPTION>.
 
-
-
-# encoding: utf-8
 
 class Synchronizers::ReadingPosition < Synchronizers::Base
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 # Copyright (C) 2012  TEA, the ebook alternative <http://www.tea-ebook.com/>
 # 
 # This file is part of TeaBook Open Reader
@@ -19,9 +21,6 @@
 # You should have received a copy of this exception. If not, see 
 # <https://github.com/TEA-ebook/teabook-open-reader/blob/master/GPL-3-EXCEPTION>.
 
-
-
-# encoding: utf-8
 
 class User
   include Mongoid::Document

--- a/app/uploaders/cover_uploader.rb
+++ b/app/uploaders/cover_uploader.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 # Copyright (C) 2012  TEA, the ebook alternative <http://www.tea-ebook.com/>
 # 
 # This file is part of TeaBook Open Reader
@@ -19,9 +21,6 @@
 # You should have received a copy of this exception. If not, see 
 # <https://github.com/TEA-ebook/teabook-open-reader/blob/master/GPL-3-EXCEPTION>.
 
-
-
-# encoding: utf-8
 
 class CoverUploader < CarrierWave::Uploader::Base
 

--- a/app/uploaders/ebook_uploader.rb
+++ b/app/uploaders/ebook_uploader.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 # Copyright (C) 2012  TEA, the ebook alternative <http://www.tea-ebook.com/>
 # 
 # This file is part of TeaBook Open Reader
@@ -19,9 +21,6 @@
 # You should have received a copy of this exception. If not, see 
 # <https://github.com/TEA-ebook/teabook-open-reader/blob/master/GPL-3-EXCEPTION>.
 
-
-
-# encoding: utf-8
 
 class EbookUploader < CarrierWave::Uploader::Base
 

--- a/app/workers/download_ebook_worker.rb
+++ b/app/workers/download_ebook_worker.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 # Copyright (C) 2012  TEA, the ebook alternative <http://www.tea-ebook.com/>
 # 
 # This file is part of TeaBook Open Reader
@@ -19,9 +21,6 @@
 # You should have received a copy of this exception. If not, see 
 # <https://github.com/TEA-ebook/teabook-open-reader/blob/master/GPL-3-EXCEPTION>.
 
-
-
-# encoding: utf-8
 
 class DownloadEbookWorker
   @queue = :download_ebook

--- a/app/workers/epub_to_html_worker.rb
+++ b/app/workers/epub_to_html_worker.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 # Copyright (C) 2012  TEA, the ebook alternative <http://www.tea-ebook.com/>
 # 
 # This file is part of TeaBook Open Reader
@@ -19,9 +21,6 @@
 # You should have received a copy of this exception. If not, see 
 # <https://github.com/TEA-ebook/teabook-open-reader/blob/master/GPL-3-EXCEPTION>.
 
-
-
-# encoding: utf-8
 
 class EpubToHTMLWorker
   @queue = :epub_to_html

--- a/app/workers/extract_epub_worker.rb
+++ b/app/workers/extract_epub_worker.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 # Copyright (C) 2012  TEA, the ebook alternative <http://www.tea-ebook.com/>
 # 
 # This file is part of TeaBook Open Reader
@@ -19,9 +21,6 @@
 # You should have received a copy of this exception. If not, see 
 # <https://github.com/TEA-ebook/teabook-open-reader/blob/master/GPL-3-EXCEPTION>.
 
-
-
-# encoding: utf-8
 
 class ExtractEpubWorker
   @queue = :extract_epub

--- a/app/workers/import_books_worker.rb
+++ b/app/workers/import_books_worker.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 # Copyright (C) 2012  TEA, the ebook alternative <http://www.tea-ebook.com/>
 # 
 # This file is part of TeaBook Open Reader
@@ -19,9 +21,6 @@
 # You should have received a copy of this exception. If not, see 
 # <https://github.com/TEA-ebook/teabook-open-reader/blob/master/GPL-3-EXCEPTION>.
 
-
-
-# encoding: utf-8
 
 class ImportBooksWorker
   @queue = :import_books

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 # Copyright (C) 2012  TEA, the ebook alternative <http://www.tea-ebook.com/>
 # 
 # This file is part of TeaBook Open Reader
@@ -20,8 +22,6 @@
 # <https://github.com/TEA-ebook/teabook-open-reader/blob/master/GPL-3-EXCEPTION>.
 
 
-
-# encoding: utf-8
 require File.expand_path('../boot', __FILE__)
 
 # Pick the frameworks you want:

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 # Copyright (C) 2012  TEA, the ebook alternative <http://www.tea-ebook.com/>
 # 
 # This file is part of TeaBook Open Reader
@@ -20,8 +22,6 @@
 # <https://github.com/TEA-ebook/teabook-open-reader/blob/master/GPL-3-EXCEPTION>.
 
 
-
-# encoding: utf-8
 require 'rubygems'
 
 # Set up gems listed in the Gemfile.

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 # Copyright (C) 2012  TEA, the ebook alternative <http://www.tea-ebook.com/>
 # 
 # This file is part of TeaBook Open Reader
@@ -20,8 +22,6 @@
 # <https://github.com/TEA-ebook/teabook-open-reader/blob/master/GPL-3-EXCEPTION>.
 
 
-
-# encoding: utf-8
 # Load the rails application
 require File.expand_path('../application', __FILE__)
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 # Copyright (C) 2012  TEA, the ebook alternative <http://www.tea-ebook.com/>
 # 
 # This file is part of TeaBook Open Reader
@@ -19,9 +21,6 @@
 # You should have received a copy of this exception. If not, see 
 # <https://github.com/TEA-ebook/teabook-open-reader/blob/master/GPL-3-EXCEPTION>.
 
-
-
-# encoding: utf-8
 Tea::Application.configure do
   # Settings specified here will take precedence over those in config/application.rb
   DOMAIN = 'local.host'

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 # Copyright (C) 2012  TEA, the ebook alternative <http://www.tea-ebook.com/>
 # 
 # This file is part of TeaBook Open Reader
@@ -20,8 +22,6 @@
 # <https://github.com/TEA-ebook/teabook-open-reader/blob/master/GPL-3-EXCEPTION>.
 
 
-
-# encoding: utf-8
 Tea::Application.configure do
   # Settings specified here will take precedence over those in config/application.rb
   DOMAIN = 'local.host'

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 # Copyright (C) 2012  TEA, the ebook alternative <http://www.tea-ebook.com/>
 # 
 # This file is part of TeaBook Open Reader
@@ -20,8 +22,6 @@
 # <https://github.com/TEA-ebook/teabook-open-reader/blob/master/GPL-3-EXCEPTION>.
 
 
-
-# encoding: utf-8
 Tea::Application.configure do
   # Settings specified here will take precedence over those in config/application.rb
   DOMAIN = 'test.host'

--- a/config/initializers/backtrace_silencers.rb
+++ b/config/initializers/backtrace_silencers.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 # Copyright (C) 2012  TEA, the ebook alternative <http://www.tea-ebook.com/>
 # 
 # This file is part of TeaBook Open Reader
@@ -21,7 +23,6 @@
 
 
 
-# encoding: utf-8
 # Be sure to restart your server when you modify this file.
 
 # You can add backtrace silencers for libraries that you're using but don't wish to see in your backtraces.

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 # Copyright (C) 2012  TEA, the ebook alternative <http://www.tea-ebook.com/>
 # 
 # This file is part of TeaBook Open Reader
@@ -20,8 +22,6 @@
 # <https://github.com/TEA-ebook/teabook-open-reader/blob/master/GPL-3-EXCEPTION>.
 
 
-
-# encoding: utf-8
 # Use this hook to configure devise mailer, warden hooks and so forth.
 # Many of these configuration options can be set straight in your model.
 Devise.setup do |config|

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 # Copyright (C) 2012  TEA, the ebook alternative <http://www.tea-ebook.com/>
 # 
 # This file is part of TeaBook Open Reader
@@ -20,8 +22,6 @@
 # <https://github.com/TEA-ebook/teabook-open-reader/blob/master/GPL-3-EXCEPTION>.
 
 
-
-# encoding: utf-8
 # Be sure to restart your server when you modify this file.
 
 # Add new inflection rules using the following format

--- a/config/initializers/mime_types.rb
+++ b/config/initializers/mime_types.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 # Copyright (C) 2012  TEA, the ebook alternative <http://www.tea-ebook.com/>
 # 
 # This file is part of TeaBook Open Reader
@@ -20,8 +22,6 @@
 # <https://github.com/TEA-ebook/teabook-open-reader/blob/master/GPL-3-EXCEPTION>.
 
 
-
-# encoding: utf-8
 # Be sure to restart your server when you modify this file.
 
 # Add new mime types for use in respond_to blocks:

--- a/config/initializers/redis.rb
+++ b/config/initializers/redis.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 # Copyright (C) 2012  TEA, the ebook alternative <http://www.tea-ebook.com/>
 # 
 # This file is part of TeaBook Open Reader
@@ -20,8 +22,6 @@
 # <https://github.com/TEA-ebook/teabook-open-reader/blob/master/GPL-3-EXCEPTION>.
 
 
-
-# encoding: utf-8
 config = YAML.load_file File.expand_path("../../redis.yml", __FILE__)
 $redis = Redis.connect config[Rails.env]
 Resque.redis = $redis

--- a/config/initializers/secret_token.rb
+++ b/config/initializers/secret_token.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 # Copyright (C) 2012  TEA, the ebook alternative <http://www.tea-ebook.com/>
 # 
 # This file is part of TeaBook Open Reader
@@ -20,8 +22,6 @@
 # <https://github.com/TEA-ebook/teabook-open-reader/blob/master/GPL-3-EXCEPTION>.
 
 
-
-# encoding: utf-8
 # Be sure to restart your server when you modify this file.
 
 # Your secret key for verifying the integrity of signed cookies.

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 # Copyright (C) 2012  TEA, the ebook alternative <http://www.tea-ebook.com/>
 # 
 # This file is part of TeaBook Open Reader
@@ -20,8 +22,6 @@
 # <https://github.com/TEA-ebook/teabook-open-reader/blob/master/GPL-3-EXCEPTION>.
 
 
-
-# encoding: utf-8
 # Be sure to restart your server when you modify this file.
 
 Tea::Application.config.session_store :cookie_store, key: '_tea_session'

--- a/config/initializers/simple_form.rb
+++ b/config/initializers/simple_form.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 # Copyright (C) 2012  TEA, the ebook alternative <http://www.tea-ebook.com/>
 # 
 # This file is part of TeaBook Open Reader
@@ -20,8 +22,6 @@
 # <https://github.com/TEA-ebook/teabook-open-reader/blob/master/GPL-3-EXCEPTION>.
 
 
-
-# encoding: utf-8
 # Use this setup block to configure all options available in SimpleForm.
 SimpleForm.setup do |config|
   # Wrappers are used by the form builder to generate a

--- a/config/initializers/wrap_parameters.rb
+++ b/config/initializers/wrap_parameters.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 # Copyright (C) 2012  TEA, the ebook alternative <http://www.tea-ebook.com/>
 # 
 # This file is part of TeaBook Open Reader
@@ -20,8 +22,6 @@
 # <https://github.com/TEA-ebook/teabook-open-reader/blob/master/GPL-3-EXCEPTION>.
 
 
-
-# encoding: utf-8
 # Be sure to restart your server when you modify this file.
 #
 # This file contains settings for ActionController::ParamsWrapper which

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 # Copyright (C) 2012  TEA, the ebook alternative <http://www.tea-ebook.com/>
 # 
 # This file is part of TeaBook Open Reader
@@ -20,8 +22,6 @@
 # <https://github.com/TEA-ebook/teabook-open-reader/blob/master/GPL-3-EXCEPTION>.
 
 
-
-# encoding: utf-8
 Tea::Application.routes.draw do
 
   root to: 'tea_sessions#new'

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 # Copyright (C) 2012  TEA, the ebook alternative <http://www.tea-ebook.com/>
 # 
 # This file is part of TeaBook Open Reader
@@ -19,7 +21,6 @@
 # You should have received a copy of this exception. If not, see 
 # <https://github.com/TEA-ebook/teabook-open-reader/blob/master/GPL-3-EXCEPTION>.
 
-# encoding: utf-8
 # This file should contain all the record creation needed to seed the database with its default values.
 # The data can then be loaded with the rake db:seed (or created alongside the db with db:setup).
 #

--- a/lib/tasks/ebook.rake
+++ b/lib/tasks/ebook.rake
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 # Copyright (C) 2012  TEA, the ebook alternative <http://www.tea-ebook.com/>
 # 
 # This file is part of TeaBook Open Reader
@@ -19,7 +21,6 @@
 # You should have received a copy of this exception. If not, see 
 # <https://github.com/TEA-ebook/teabook-open-reader/blob/master/GPL-3-EXCEPTION>.
 
-# encoding: utf-8
 namespace :ebook do
 
   namespace :import do

--- a/lib/tasks/resque.rake
+++ b/lib/tasks/resque.rake
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 # Copyright (C) 2012  TEA, the ebook alternative <http://www.tea-ebook.com/>
 # 
 # This file is part of TeaBook Open Reader
@@ -20,7 +22,6 @@
 # <https://github.com/TEA-ebook/teabook-open-reader/blob/master/GPL-3-EXCEPTION>.
 
 
-# encoding: utf-8
 require 'resque/pool/tasks'
 
 namespace :resque do

--- a/spec/controllers/annotations_controller_spec.rb
+++ b/spec/controllers/annotations_controller_spec.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 # Copyright (C) 2012  TEA, the ebook alternative <http://www.tea-ebook.com/>
 # 
 # This file is part of TeaBook Open Reader
@@ -19,9 +21,6 @@
 # You should have received a copy of this exception. If not, see 
 # <https://github.com/TEA-ebook/teabook-open-reader/blob/master/GPL-3-EXCEPTION>.
 
-
-
-# encoding: utf-8
 
 require 'spec_helper'
 

--- a/spec/controllers/bookmarks_controller_spec.rb
+++ b/spec/controllers/bookmarks_controller_spec.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 # Copyright (C) 2012  TEA, the ebook alternative <http://www.tea-ebook.com/>
 # 
 # This file is part of TeaBook Open Reader
@@ -19,9 +21,6 @@
 # You should have received a copy of this exception. If not, see 
 # <https://github.com/TEA-ebook/teabook-open-reader/blob/master/GPL-3-EXCEPTION>.
 
-
-
-# encoding: utf-8
 
 require 'spec_helper'
 

--- a/spec/controllers/ebook/epubs_controller_spec.rb
+++ b/spec/controllers/ebook/epubs_controller_spec.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 # Copyright (C) 2012  TEA, the ebook alternative <http://www.tea-ebook.com/>
 # 
 # This file is part of TeaBook Open Reader
@@ -20,8 +22,6 @@
 # <https://github.com/TEA-ebook/teabook-open-reader/blob/master/GPL-3-EXCEPTION>.
 
 
-
-# encoding: utf-8
 require 'spec_helper'
 
 describe Ebook::EpubsController do

--- a/spec/controllers/manifests_controller_spec.rb
+++ b/spec/controllers/manifests_controller_spec.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 # Copyright (C) 2012  TEA, the ebook alternative <http://www.tea-ebook.com/>
 # 
 # This file is part of TeaBook Open Reader
@@ -20,8 +22,6 @@
 # <https://github.com/TEA-ebook/teabook-open-reader/blob/master/GPL-3-EXCEPTION>.
 
 
-
-# encoding: utf-8
 require 'spec_helper'
 
 describe ManifestsController do

--- a/spec/fabricators/book_location_fabricator.rb
+++ b/spec/fabricators/book_location_fabricator.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 # Copyright (C) 2012  TEA, the ebook alternative <http://www.tea-ebook.com/>
 # 
 # This file is part of TeaBook Open Reader
@@ -19,9 +21,6 @@
 # You should have received a copy of this exception. If not, see 
 # <https://github.com/TEA-ebook/teabook-open-reader/blob/master/GPL-3-EXCEPTION>.
 
-
-
-# encoding: utf-8
 
 Fabricator(:book_location) do
   book(fabricator: :ebook_epub)

--- a/spec/fabricators/ebook_epub_chapter_fabricator.rb
+++ b/spec/fabricators/ebook_epub_chapter_fabricator.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 # Copyright (C) 2012  TEA, the ebook alternative <http://www.tea-ebook.com/>
 # 
 # This file is part of TeaBook Open Reader
@@ -20,7 +22,5 @@
 # <https://github.com/TEA-ebook/teabook-open-reader/blob/master/GPL-3-EXCEPTION>.
 
 
-
-# encoding: utf-8
 Fabricator(:ebook_chapter_component, class_name: 'Ebook::Epub::Chapter') do
 end

--- a/spec/fabricators/ebook_epub_component_fabricator.rb
+++ b/spec/fabricators/ebook_epub_component_fabricator.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 # Copyright (C) 2012  TEA, the ebook alternative <http://www.tea-ebook.com/>
 # 
 # This file is part of TeaBook Open Reader
@@ -19,9 +21,6 @@
 # You should have received a copy of this exception. If not, see 
 # <https://github.com/TEA-ebook/teabook-open-reader/blob/master/GPL-3-EXCEPTION>.
 
-
-
-# encoding: utf-8
 
 Fabricator(:ebook_epub_component, class_name: 'Ebook::Epub::Component') do
   src     { "#{Faker::Lorem.word }.html" }

--- a/spec/fabricators/ebook_fabricator.rb
+++ b/spec/fabricators/ebook_fabricator.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 # Copyright (C) 2012  TEA, the ebook alternative <http://www.tea-ebook.com/>
 # 
 # This file is part of TeaBook Open Reader
@@ -20,8 +22,6 @@
 # <https://github.com/TEA-ebook/teabook-open-reader/blob/master/GPL-3-EXCEPTION>.
 
 
-
-# encoding: utf-8
 Fabricator(:ebook, class_name: 'Ebook::Base') do
   file {
     File.open(File.join(Rails.root, 'spec/fixtures/Dictionnaire des idées reçues.epub'))

--- a/spec/fabricators/user_fabricator.rb
+++ b/spec/fabricators/user_fabricator.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 # Copyright (C) 2012  TEA, the ebook alternative <http://www.tea-ebook.com/>
 # 
 # This file is part of TeaBook Open Reader
@@ -19,9 +21,6 @@
 # You should have received a copy of this exception. If not, see 
 # <https://github.com/TEA-ebook/teabook-open-reader/blob/master/GPL-3-EXCEPTION>.
 
-
-
-# encoding: utf-8
 
 Fabricator(:user) do
   #email { Faker::Internet.email }

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 # Copyright (C) 2012  TEA, the ebook alternative <http://www.tea-ebook.com/>
 # 
 # This file is part of TeaBook Open Reader
@@ -20,8 +22,6 @@
 # <https://github.com/TEA-ebook/teabook-open-reader/blob/master/GPL-3-EXCEPTION>.
 
 
-
-# encoding: utf-8
 require 'spec_helper'
 
 describe ApplicationHelper do

--- a/spec/mocks/tea_api_session.rb
+++ b/spec/mocks/tea_api_session.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 # Copyright (C) 2012  TEA, the ebook alternative <http://www.tea-ebook.com/>
 # 
 # This file is part of TeaBook Open Reader
@@ -20,8 +22,6 @@
 # <https://github.com/TEA-ebook/teabook-open-reader/blob/master/GPL-3-EXCEPTION>.
 
 
-
-# encoding: utf-8
 
 def mock_tea_api_session(stubs={})
   mock = mock_model(TeaApi::Session, stubs)

--- a/spec/mocks/user.rb
+++ b/spec/mocks/user.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 # Copyright (C) 2012  TEA, the ebook alternative <http://www.tea-ebook.com/>
 # 
 # This file is part of TeaBook Open Reader
@@ -20,8 +22,6 @@
 # <https://github.com/TEA-ebook/teabook-open-reader/blob/master/GPL-3-EXCEPTION>.
 
 
-
-# encoding: utf-8
 
 def mock_user(stubs={})
   mock = mock_model(User, stubs)

--- a/spec/models/annotation_spec.rb
+++ b/spec/models/annotation_spec.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 # Copyright (C) 2012  TEA, the ebook alternative <http://www.tea-ebook.com/>
 # 
 # This file is part of TeaBook Open Reader
@@ -20,8 +22,6 @@
 # <https://github.com/TEA-ebook/teabook-open-reader/blob/master/GPL-3-EXCEPTION>.
 
 
-
-# encoding: utf-8
 
 require 'spec_helper'
 

--- a/spec/models/book_location_spec.rb
+++ b/spec/models/book_location_spec.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 # Copyright (C) 2012  TEA, the ebook alternative <http://www.tea-ebook.com/>
 # 
 # This file is part of TeaBook Open Reader
@@ -19,9 +21,6 @@
 # You should have received a copy of this exception. If not, see 
 # <https://github.com/TEA-ebook/teabook-open-reader/blob/master/GPL-3-EXCEPTION>.
 
-
-
-# encoding: utf-8
 
 require 'spec_helper'
 

--- a/spec/models/bookmark_spec.rb
+++ b/spec/models/bookmark_spec.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 # Copyright (C) 2012  TEA, the ebook alternative <http://www.tea-ebook.com/>
 # 
 # This file is part of TeaBook Open Reader
@@ -19,9 +21,6 @@
 # You should have received a copy of this exception. If not, see 
 # <https://github.com/TEA-ebook/teabook-open-reader/blob/master/GPL-3-EXCEPTION>.
 
-
-
-# encoding: utf-8
 
 require 'spec_helper'
 

--- a/spec/models/ebook/base_spec.rb
+++ b/spec/models/ebook/base_spec.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 # Copyright (C) 2012  TEA, the ebook alternative <http://www.tea-ebook.com/>
 # 
 # This file is part of TeaBook Open Reader
@@ -20,8 +22,6 @@
 # <https://github.com/TEA-ebook/teabook-open-reader/blob/master/GPL-3-EXCEPTION>.
 
 
-
-# encoding: utf-8
 require 'spec_helper'
 
 describe Ebook::Base do

--- a/spec/models/ebook/epub/chapter_spec.rb
+++ b/spec/models/ebook/epub/chapter_spec.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 # Copyright (C) 2012  TEA, the ebook alternative <http://www.tea-ebook.com/>
 # 
 # This file is part of TeaBook Open Reader
@@ -20,8 +22,6 @@
 # <https://github.com/TEA-ebook/teabook-open-reader/blob/master/GPL-3-EXCEPTION>.
 
 
-
-# encoding: utf-8
 require 'spec_helper'
 
 describe Ebook::Epub::Chapter do

--- a/spec/models/ebook/epub/component_spec.rb
+++ b/spec/models/ebook/epub/component_spec.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 # Copyright (C) 2012  TEA, the ebook alternative <http://www.tea-ebook.com/>
 # 
 # This file is part of TeaBook Open Reader
@@ -20,8 +22,6 @@
 # <https://github.com/TEA-ebook/teabook-open-reader/blob/master/GPL-3-EXCEPTION>.
 
 
-
-# encoding: utf-8
 require 'spec_helper'
 
 describe Ebook::Epub::Component do

--- a/spec/models/ebook/epub_spec.rb
+++ b/spec/models/ebook/epub_spec.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 # Copyright (C) 2012  TEA, the ebook alternative <http://www.tea-ebook.com/>
 # 
 # This file is part of TeaBook Open Reader
@@ -20,8 +22,6 @@
 # <https://github.com/TEA-ebook/teabook-open-reader/blob/master/GPL-3-EXCEPTION>.
 
 
-
-# encoding: utf-8
 require 'spec_helper'
 
 describe Ebook::Epub do

--- a/spec/models/epub_cfi_spec.rb
+++ b/spec/models/epub_cfi_spec.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 # Copyright (C) 2012  TEA, the ebook alternative <http://www.tea-ebook.com/>
 # 
 # This file is part of TeaBook Open Reader
@@ -19,9 +21,6 @@
 # You should have received a copy of this exception. If not, see 
 # <https://github.com/TEA-ebook/teabook-open-reader/blob/master/GPL-3-EXCEPTION>.
 
-
-
-# encoding: utf-8
 
 require "spec_helper_lite"
 require "app/models/epub_cfi"

--- a/spec/models/reading_position_spec.rb
+++ b/spec/models/reading_position_spec.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 # Copyright (C) 2012  TEA, the ebook alternative <http://www.tea-ebook.com/>
 # 
 # This file is part of TeaBook Open Reader
@@ -20,8 +22,6 @@
 # <https://github.com/TEA-ebook/teabook-open-reader/blob/master/GPL-3-EXCEPTION>.
 
 
-
-# encoding: utf-8
 
 require 'spec_helper'
 

--- a/spec/models/synchronizers/base_spec.rb
+++ b/spec/models/synchronizers/base_spec.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 # Copyright (C) 2012  TEA, the ebook alternative <http://www.tea-ebook.com/>
 # 
 # This file is part of TeaBook Open Reader
@@ -20,8 +22,6 @@
 # <https://github.com/TEA-ebook/teabook-open-reader/blob/master/GPL-3-EXCEPTION>.
 
 
-
-# encoding: utf-8
 
 require "spec_helper_lite"
 

--- a/spec/models/synchronizers/reading_position_spec.rb
+++ b/spec/models/synchronizers/reading_position_spec.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 # Copyright (C) 2012  TEA, the ebook alternative <http://www.tea-ebook.com/>
 # 
 # This file is part of TeaBook Open Reader
@@ -19,9 +21,6 @@
 # You should have received a copy of this exception. If not, see 
 # <https://github.com/TEA-ebook/teabook-open-reader/blob/master/GPL-3-EXCEPTION>.
 
-
-
-# encoding: utf-8
 
 require "spec_helper_lite"
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 # Copyright (C) 2012  TEA, the ebook alternative <http://www.tea-ebook.com/>
 # 
 # This file is part of TeaBook Open Reader
@@ -19,9 +21,6 @@
 # You should have received a copy of this exception. If not, see 
 # <https://github.com/TEA-ebook/teabook-open-reader/blob/master/GPL-3-EXCEPTION>.
 
-
-
-# encoding: utf-8
 
 require 'spec_helper'
 

--- a/spec/routing/annotations_routing_spec.rb
+++ b/spec/routing/annotations_routing_spec.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 # Copyright (C) 2012  TEA, the ebook alternative <http://www.tea-ebook.com/>
 # 
 # This file is part of TeaBook Open Reader
@@ -20,8 +22,6 @@
 # <https://github.com/TEA-ebook/teabook-open-reader/blob/master/GPL-3-EXCEPTION>.
 
 
-
-# encoding: utf-8
 require "spec_helper"
 
 describe AnnotationsController do

--- a/spec/routing/bookmarks_routing_spec.rb
+++ b/spec/routing/bookmarks_routing_spec.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 # Copyright (C) 2012  TEA, the ebook alternative <http://www.tea-ebook.com/>
 # 
 # This file is part of TeaBook Open Reader
@@ -20,8 +22,6 @@
 # <https://github.com/TEA-ebook/teabook-open-reader/blob/master/GPL-3-EXCEPTION>.
 
 
-
-# encoding: utf-8
 require "spec_helper"
 
 describe BookmarksController do

--- a/spec/routing/ebook/epub/chapters_routing_spec.rb
+++ b/spec/routing/ebook/epub/chapters_routing_spec.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 # Copyright (C) 2012  TEA, the ebook alternative <http://www.tea-ebook.com/>
 # 
 # This file is part of TeaBook Open Reader
@@ -20,8 +22,6 @@
 # <https://github.com/TEA-ebook/teabook-open-reader/blob/master/GPL-3-EXCEPTION>.
 
 
-
-# encoding: utf-8
 require "spec_helper"
 
 describe Ebook::Epub::ChaptersController do

--- a/spec/routing/ebook/epub/components_routing_spec.rb
+++ b/spec/routing/ebook/epub/components_routing_spec.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 # Copyright (C) 2012  TEA, the ebook alternative <http://www.tea-ebook.com/>
 # 
 # This file is part of TeaBook Open Reader
@@ -20,8 +22,6 @@
 # <https://github.com/TEA-ebook/teabook-open-reader/blob/master/GPL-3-EXCEPTION>.
 
 
-
-# encoding: utf-8
 require "spec_helper"
 
 describe Ebook::Epub::ComponentsController do

--- a/spec/routing/ebook/epubs_routing_spec.rb
+++ b/spec/routing/ebook/epubs_routing_spec.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 # Copyright (C) 2012  TEA, the ebook alternative <http://www.tea-ebook.com/>
 # 
 # This file is part of TeaBook Open Reader
@@ -20,8 +22,6 @@
 # <https://github.com/TEA-ebook/teabook-open-reader/blob/master/GPL-3-EXCEPTION>.
 
 
-
-# encoding: utf-8
 require "spec_helper"
 
 describe Ebook::EpubsController do

--- a/spec/routing/manifests_routing_spec.rb
+++ b/spec/routing/manifests_routing_spec.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 # Copyright (C) 2012  TEA, the ebook alternative <http://www.tea-ebook.com/>
 # 
 # This file is part of TeaBook Open Reader
@@ -20,8 +22,6 @@
 # <https://github.com/TEA-ebook/teabook-open-reader/blob/master/GPL-3-EXCEPTION>.
 
 
-
-# encoding: utf-8
 require "spec_helper"
 
 describe ManifestsController do

--- a/spec/routing/reading_position_routing_spec.rb
+++ b/spec/routing/reading_position_routing_spec.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 # Copyright (C) 2012  TEA, the ebook alternative <http://www.tea-ebook.com/>
 # 
 # This file is part of TeaBook Open Reader
@@ -20,8 +22,6 @@
 # <https://github.com/TEA-ebook/teabook-open-reader/blob/master/GPL-3-EXCEPTION>.
 
 
-
-# encoding: utf-8
 require "spec_helper"
 
 describe ReadingPositionController do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 # Copyright (C) 2012  TEA, the ebook alternative <http://www.tea-ebook.com/>
 # 
 # This file is part of TeaBook Open Reader
@@ -20,8 +22,6 @@
 # <https://github.com/TEA-ebook/teabook-open-reader/blob/master/GPL-3-EXCEPTION>.
 
 
-
-# encoding: utf-8
 
 require 'simplecov'
 SimpleCov.start 'rails'

--- a/spec/spec_helper_lite.rb
+++ b/spec/spec_helper_lite.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 # Copyright (C) 2012  TEA, the ebook alternative <http://www.tea-ebook.com/>
 # 
 # This file is part of TeaBook Open Reader
@@ -19,9 +21,6 @@
 # You should have received a copy of this exception. If not, see 
 # <https://github.com/TEA-ebook/teabook-open-reader/blob/master/GPL-3-EXCEPTION>.
 
-
-
-# encoding: utf-8
 
 unless defined? RAILS_ROOT
   RAILS_ROOT = File.expand_path(File.dirname(__FILE__) + '/../')

--- a/spec/support/controller_macros.rb
+++ b/spec/support/controller_macros.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 # Copyright (C) 2012  TEA, the ebook alternative <http://www.tea-ebook.com/>
 # 
 # This file is part of TeaBook Open Reader
@@ -19,9 +21,6 @@
 # You should have received a copy of this exception. If not, see 
 # <https://github.com/TEA-ebook/teabook-open-reader/blob/master/GPL-3-EXCEPTION>.
 
-
-
-# encoding: utf-8
 
 module ControllerMacros
 

--- a/spec/workers/epub_to_html_worker_spec.rb
+++ b/spec/workers/epub_to_html_worker_spec.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 # Copyright (C) 2012  TEA, the ebook alternative <http://www.tea-ebook.com/>
 # 
 # This file is part of TeaBook Open Reader
@@ -20,8 +22,6 @@
 # <https://github.com/TEA-ebook/teabook-open-reader/blob/master/GPL-3-EXCEPTION>.
 
 
-
-# encoding: utf-8
 require 'spec_helper'
 
 describe EpubToHTMLWorker do

--- a/spec/workers/extract_epub_worker_spec.rb
+++ b/spec/workers/extract_epub_worker_spec.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 # Copyright (C) 2012  TEA, the ebook alternative <http://www.tea-ebook.com/>
 # 
 # This file is part of TeaBook Open Reader
@@ -20,8 +22,6 @@
 # <https://github.com/TEA-ebook/teabook-open-reader/blob/master/GPL-3-EXCEPTION>.
 
 
-
-# encoding: utf-8
 require 'spec_helper'
 
 describe ExtractEpubWorker do


### PR DESCRIPTION
Update the `# encoding: utf-8` special comment for ruby files
see #3
