### PR TITLE
Add a button to go back to the reading after following an internal link

### DIFF
--- a/app/assets/javascripts/misc/anchor_binder.js.coffee
+++ b/app/assets/javascripts/misc/anchor_binder.js.coffee
@@ -25,7 +25,7 @@
 # internal links and bind a Monocle moveTo to the click event.
 
 class App.Misc.AnchorBinder
-  constructor: (@reader, @view) ->
+  constructor: (@reader, @view, @anchorGoBack) ->
 
   process: ()=>
     _.each @view.contentFrames(), (contentFrame)=>
@@ -56,7 +56,14 @@ class App.Misc.AnchorBinder
   bindInternalLink: (link, locus)->
     link.on 'click', (event)=>
       event.preventDefault()
-      @reader.moveTo locus
+      if @anchorGoBack.can(link[0].href)
+        # go back using the "real" last position
+        # and not the position of the anchor
+        @anchorGoBack.go()
+      else
+        # just follow the link
+        @anchorGoBack.followLinkFrom link[0].id
+        @reader.moveTo locus
 
   bindExternalLink: (link)->
     link.on 'click', (event)->

--- a/app/assets/javascripts/misc/anchor_go_back.js.coffee
+++ b/app/assets/javascripts/misc/anchor_go_back.js.coffee
@@ -1,0 +1,56 @@
+# Copyright (C) 2012  TEA, the ebook alternative <http://www.tea-ebook.com/>
+#
+# This file is part of TeaBook Open Reader
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, version 3.0 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# An additional permission has been granted as a special exception
+# to the GNU General Public Licence.
+# You should have received a copy of this exception. If not, see
+# <https://github.com/TEA-ebook/teabook-open-reader/blob/master/GPL-3-EXCEPTION>.
+
+# The AnchorGoBack allow to go to the previous reading position
+# after click a link, as a footnote.
+class App.Misc.AnchorGoBack
+  constructor: (@reader, @goBackLink) ->
+    @linkStack = []
+    @goBackLink.hide()
+
+  # Go back using the filled link stack
+  # and hide the button stack is empty
+  go: () ->
+    if @linkStack.length > 0
+      last = @linkStack.pop()
+      @reader.moveTo last.position
+    if @linkStack.length == 0
+      @goBackLink.hide()
+
+  # Indicate the GoBack object the user follow a link
+  # The id is saved to be able to return to the real
+  # initial position even if the user click a real
+  # back link.
+  followLinkFrom: (id) ->
+    currentLocus = @reader.getPlace().getLocus()
+    @linkStack.push(position: currentLocus, srcid: id)
+    @goBackLink.show()
+
+  # Check if the link the user wants to follow
+  # return to the last position saved in the stack.
+  # If yes, you can call a `go()` just after that to
+  # allow to user to be positionned just before clicking
+  # the first link and not move to the anchor position.
+  can: (href) ->
+    return false if @linkStack.length == 0
+    last = @linkStack[@linkStack.length - 1]
+    matches = href.match /^.*#(.+)$/
+    return matches[1] == last.srcid

--- a/app/assets/javascripts/views/ebook_reader_sandbox.js.coffee
+++ b/app/assets/javascripts/views/ebook_reader_sandbox.js.coffee
@@ -28,6 +28,7 @@ class App.Views.EbookReaderSandbox extends Backbone.View
     'click .details':     'toggleDetails'
     'click .settings':    'toggleSettings'
     'click .library':     'backToLibrary'
+    'click .goback':      'goBackLink'
     'mouseover #reader':  'showMenu'
     'keydown':            'keydown'
 
@@ -104,8 +105,10 @@ class App.Views.EbookReaderSandbox extends Backbone.View
     @settingsPanel = new App.Views.SettingsPanel(reader: @reader)
     @$el.append @settingsPanel.render().el
 
+    # Go back link
+    @anchorGoBack = new App.Misc.AnchorGoBack(@reader, $('a.menu.goback'))
     # Anchor binder
-    @anchorBinder = new App.Misc.AnchorBinder(@reader, @)
+    @anchorBinder = new App.Misc.AnchorBinder(@reader, @, @anchorGoBack)
     reader.listen 'monocle:loaded', @anchorBinder.process
     reader.listen 'monocle:componentchange', @anchorBinder.process
 
@@ -257,3 +260,7 @@ class App.Views.EbookReaderSandbox extends Backbone.View
     App.messages.send
       type: 'navigate'
       content: '/ebook/epubs'
+
+  goBackLink: (e) =>
+    e.preventDefault()
+    @anchorGoBack.go()

--- a/app/assets/stylesheets/reader_custom.css.sass
+++ b/app/assets/stylesheets/reader_custom.css.sass
@@ -129,6 +129,8 @@ body
           content: "\f05a"
         &.annotate::after
           content: "\f044"
+        &.goback::after
+          content: "\f048"
         &.settings
           &::before
             border: 0
@@ -260,7 +262,7 @@ body
       position: absolute
       top: -40px
       right: 9%
-      left: 17%
+      left: 26%
       //opacity: 0
       color: #53656f
       font: italic 13px/15px "Museo 500"

--- a/app/templates/ebook/_menu.mustache
+++ b/app/templates/ebook/_menu.mustache
@@ -24,5 +24,6 @@
 <a href="/ebook/epubs" class="menu library" title="Bibliothèque">Bibliothèque</a>
 <!--<a href="#" class="menu layout" title="Chargement en cours…">Chargement en cours…</a>-->
 <a href="#" class="menu details" title="Informations">Informations</a>
+<a href="#" class="menu goback" title="Retour">Retour</a>
 <!--<a href="#" class="menu annotate" title="Annoter">Annoter</a>-->
 <a href="#" class="menu right settings" title="Paramètres">Paramètres</a>

--- a/spec/javascripts/spec/misc/anchor_go_back_spec.coffee
+++ b/spec/javascripts/spec/misc/anchor_go_back_spec.coffee
@@ -1,0 +1,124 @@
+# Copyright (C) 2012  TEA, the ebook alternative <http://www.tea-ebook.com/>
+#
+# This file is part of TeaBook Open Reader
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, version 3.0 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# An additional permission has been granted as a special exception
+# to the GNU General Public Licence.
+# You should have received a copy of this exception. If not, see
+# <https://github.com/TEA-ebook/teabook-open-reader/blob/master/GPL-3-EXCEPTION>.
+
+
+
+describe 'App.Misc.AnchorGoBack', ->
+
+  it 'should be defined', ->
+    expect(App.Misc.AnchorGoBack).toBeDefined()
+
+  beforeEach ->
+    @locus = 'locus'
+    @getPlace = {
+      getLocus: ->
+
+    }
+    spyOn(@getPlace, 'getLocus').andReturn(@locus)
+    @reader = {
+      getPlace: ->
+        @getPlace
+      moveTo: ->
+    }
+    spyOn(@reader, 'getPlace').andReturn(@getPlace)
+    spyOn(@reader, 'moveTo')
+
+    @goBackLink = {
+      hide: ->
+      show: ->
+    }
+    spyOn @goBackLink, 'hide'
+    spyOn @goBackLink, 'show'
+
+    @id = 'id'
+    @goodHref = 'plop#id'
+    @badHref = 'plop#bad'
+
+    @anchorGoBack = new App.Misc.AnchorGoBack @reader, @goBackLink
+
+  it 'must hide the go back link', ->
+    expect(@goBackLink.hide.calls.length).toEqual(1)
+
+  it 'must have an empty stack when created', ->
+    expect(@anchorGoBack.linkStack.length).toEqual(0)
+
+  describe ', when follow a link,', ->
+    it 'must get the current locus', ->
+      @anchorGoBack.followLinkFrom @id
+      expect(@getPlace.getLocus.calls.length).toEqual(1)
+
+    it 'must push an item in the stack', ->
+      @anchorGoBack.followLinkFrom @id
+      expect(@anchorGoBack.linkStack.length).toEqual(1)
+
+    it 'must store current locus and source id in the stack', ->
+      @anchorGoBack.followLinkFrom @id
+      last = @anchorGoBack.linkStack[@anchorGoBack.linkStack.length - 1]
+      expect(last.position).toEqual(@locus)
+      expect(last.srcid).toEqual(@id)
+
+    it 'must show the go back link', ->
+      @anchorGoBack.followLinkFrom @id
+      expect(@goBackLink.show.calls.length).toEqual(1)
+
+  describe ', when try to go back,', ->
+    beforeEach ->
+      @goBackLink.hide.reset()
+
+    it 'must hide the link when stack is yet empty', ->
+      @anchorGoBack.go()
+      expect(@goBackLink.hide.calls.length).toEqual(1)
+
+    it 'must hide the link when stack has one element', ->
+      @anchorGoBack.followLinkFrom @id
+      @anchorGoBack.go()
+      expect(@goBackLink.hide.calls.length).toEqual(1)
+
+    it 'must not hide the link when stack is more than 2', ->
+      @anchorGoBack.followLinkFrom @id
+      @anchorGoBack.followLinkFrom @id
+      @anchorGoBack.go()
+      expect(@goBackLink.hide.calls.length).toEqual(0)
+
+    it 'must pop the last link', ->
+      @anchorGoBack.followLinkFrom @id
+      stackLength = @anchorGoBack.linkStack.length
+      @anchorGoBack.go()
+      expect(@anchorGoBack.linkStack.length).toEqual(stackLength - 1)
+
+    it 'must move to the last position', ->
+      @anchorGoBack.followLinkFrom @id
+      @anchorGoBack.go()
+      expect(@reader.moveTo.calls.length).toEqual(1)
+      expect(@reader.moveTo.mostRecentCall.args[0]).toEqual(@locus)
+
+  describe ', when ask link to follow is last origin,', ->
+
+    it 'must return false if no link was follow', ->
+      expect(@anchorGoBack.can(@goodHref)).toEqual(false)
+
+    it 'must return false if href not match with last id', ->
+      @anchorGoBack.followLinkFrom @id
+      expect(@anchorGoBack.can(@badHref)).toEqual(false)
+
+    it 'must return true if href match with last id', ->
+      @anchorGoBack.followLinkFrom @id
+      expect(@anchorGoBack.can(@goodHref)).toEqual(true)


### PR DESCRIPTION
When following a link, the position is stored. A button is
displayed and allow the user to go back to the position
before following the link. This allow to continue reading
after jumping to a footnote by example.

When the user click a link, we check if the link destination is the
same position we stored just before. By example, after jumping
to a footnote, if the user click the link which allow to return
to the mention. If positions are similar, we do not follow the link
but we go back using the stored position before going to the footnote.
