### PR TITLE
Add test environnement to development mongoid configuration 

### DIFF
--- a/config/mongoid/development.yml
+++ b/config/mongoid/development.yml
@@ -24,3 +24,7 @@
 development:
   host: localhost
   database: tea_dev
+
+test:
+  host: localhost
+  database: tea_test


### PR DESCRIPTION
In order to avoid problem seen in issue #25 after a default installation with Vagrant.
