### PR TITLE
Replace unzip command by zipruby

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,7 @@ gem 'faraday_middleware'
 gem 'hashie'
 gem 'gaston'
 gem 'responders'
+gem 'zipruby'
 
 gem 'thin'
 gem 'sinatra'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -356,3 +356,4 @@ DEPENDENCIES
   thin
   typhoeus
   uglifier (>= 1.0.3)
+  zipruby


### PR DESCRIPTION
Hi,

This pull request remove the need of using the system function in order to unzip files.

zipruby is not a new dependencies because peregrin already use it.
