### PR TITLE
Support tel:// uri scheme

### DIFF
--- a/app/models/ebook/epub.rb
+++ b/app/models/ebook/epub.rb
@@ -586,7 +586,7 @@ class Ebook::Epub < Ebook::Base
 
     document.xpath("//body//a").each do |a|
       href = a['href']
-      next if href.blank?
+      next if href.blank? or href =~ /^tel:/
 
       anchor = URI.parse(href)
       next if anchor.absolute? || anchor.path.starts_with?("#{relative_dirname}/")


### PR DESCRIPTION
Ruby URI parse doesn't support tel:// uri scheme. But in some epubs we have phone numbers which use the RFC 3966.

http://tools.ietf.org/html/rfc3966
