### PR TITLE
Fix error in generated  javascript from coffee

### DIFF
--- a/app/assets/javascripts/views/ebook_reader.js.coffee
+++ b/app/assets/javascripts/views/ebook_reader.js.coffee
@@ -42,9 +42,8 @@ class App.Views.EbookReader extends Backbone.View
     App.messages.on 'receive:navigate', @navigate
 
   fetchPosition: =>
-    @model.set 'readingPosition', new App.Models.ReadingPosition
-      book_id: @model.id
-      user_id: App.current_user.id
+    @model.set('readingPosition', new App.Models.ReadingPosition(book_id: @model.id, user_id: App.current_user.id))
+      
     if locus = @locusFromParams()
       @model.get('readingPosition').set 'locus', locus
       @initializeReader()


### PR DESCRIPTION
I don't know why it stop working for us but this lines start to stop working for us. When we have debug the generated javascript we found something strange.

The current code generate this:

```
new App.Models.ReadingPosition)({
```

But we think it should be:

```
new App.Models.ReadingPosition({
```

You can try the two syntax here:
http://coffeescript.org/#try:%23Invalid%20JS%0A%20%20%20%20%40model.set%20'readingPosition'%2C%20new%20App.Models.ReadingPosition%0A%20%20%20%20%20%20book_id%3A%20%40model.id%0A%20%20%20%20%20%20user_id%3A%20App.current_user.id%0A%0A%0A%23Valid%20JS%0A%0A%20%20%20%20%40model.set('readingPosition'%2C%20new%20App.Models.ReadingPosition(book_id%3A%20%40model.id%2C%20user_id%3A%20App.current_user.id))%0A%0A
