### PR TITLE
Broken demo: Mod: update sticky.js to 2.9

### DIFF
--- a/app/assets/javascripts/lib.js
+++ b/app/assets/javascripts/lib.js
@@ -24,7 +24,7 @@
 //= require jquery
 //= require jquery_ujs
 //= require jquery.cookie
-//= require sticky-2.8
+//= require sticky-2.9
 //= require underscore
 //= require backbone
 //= require backbone-relational

--- a/app/assets/javascripts/reader/lib.js
+++ b/app/assets/javascripts/reader/lib.js
@@ -29,7 +29,7 @@
 //= require backbone_stuff
 //= require backbone_rails_sync
 //= require backbone-forms
-//= require sticky-2.8
+//= require sticky-2.9
 //= require mustache
 //= require_tree ../../../templates
 //= require_tree ../misc

--- a/app/assets/javascripts/reader_sandbox/lib.js
+++ b/app/assets/javascripts/reader_sandbox/lib.js
@@ -33,7 +33,7 @@
 //= require backbone-forms
 //= require hammer
 //= require jquery.hammer
-//= require sticky-2.8
+//= require sticky-2.9
 //= require mustache
 //= require_tree ../../../templates
 //= require bootstrap-modal


### PR DESCRIPTION
The demo (http://demo-open-reader.tea-ebook.com/) is broken with chrome 25+.

This is just a little patch to upgrade version of sticky.js to 2.9. See https://github.com/TEA-ebook/teabook-open-reader/issues/29 for some details.

I have not tested but the difference between 2.8 and 2.9 is mainly the patch by @noplay and the other part is just an other way to access indexedDB outside global namespace.
